### PR TITLE
docs: Claude Code 実装部署の受け皿を整備

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,93 @@
+# CLAUDE.md
+
+このリポジトリで Claude Code / katy-company 実装部署が作業するときのガイド。
+実装前に最初に読むファイル。
+
+## この repo の位置づけ
+
+TechEnglish の実装は **katy-company の実装部署**（`company:implementation` → `swift-implement` スキル）が行う。
+- ルール・ビルド/アップロード手順・チェックリストの「正」は katy-company `docs/implementation/swift-guide.md`。
+- このファイルと `docs/ARCHITECTURE.md` は、そのスキルが読む **プロジェクト固有の受け皿**（構造・置き場・規約）。
+
+## Platform
+
+**iOS ネイティブ（UIKit）。** リリースは iOS のみ、IPA でアップロードする。
+
+## Repository Layout
+
+git repo ルートはこのファイルの場所。Xcode プロジェクトは 1 階層下。
+
+```
+TechEnglish/                 # ← git repo root（このCLAUDE.md）
+└── TechEnglish/             # ← Xcode プロジェクトルート（.xcworkspace はここ）
+    ├── TechEnglish.xcworkspace   # CocoaPods 使用 → 常にこれを開く（.xcodeproj ではない）
+    ├── Podfile / Podfile.lock / Pods/
+    └── TechEnglish/         # ← Swift ソース本体
+        ├── App/             # AppDelegate, SceneDelegate（起動・DI・Firebase初期化）
+        ├── Controller/      # 画面ごとの ViewController（機能別サブフォルダ）
+        ├── Service/         # 【新規】ビジネスロジック／UseCase（新規実装はここ）
+        ├── Repository/      # 【新規】データ入出力の集約（Realm/Firestore/UserDefaults）
+        ├── Model/           # 値オブジェクト・Realm オブジェクト
+        │   └── Manager/     # 既存のシングルトンService（レガシー。新規はService/へ）
+        └── View/Parts/      # 再利用 View・セル
+```
+
+> `Service/` `Repository/` は目標アーキテクチャの置き場。最初にそこへ書く機能が
+> ディレクトリを作る（既存の動いている画面は移設しない）。
+
+## 目標アーキテクチャ（新規コードの基準）
+
+**薄いレイヤード MVC。** 詳細と参照テンプレートは `docs/ARCHITECTURE.md`。
+
+```
+Controller/  ViewController … 薄く。表示・遷移・入力受けだけ
+    ↓ 呼ぶ
+Service/     ロジック・UseCase … 判断/加工はここ（既存 Manager シングルトンもこの役割）
+    ↓ 参照（プロトコル越し）
+Repository/  データ入出力を集約 … Realm / Firestore / UserDefaults をここに閉じ込める
+    ↓
+Realm（ローカル）/ Firestore（リモート）/ UserDefaults（設定）
+```
+
+**契約（守ると保守性が上がる要点）:**
+- ViewController から Realm / Firestore / UserDefaults を**直接触らない**。必ず Repository 越し（多くは Service 経由）。
+- Repository は**プロトコルで公開**し、具象（`RealmXxxRepository` 等）を DI する（テストで差し替え可能にする）。
+- Service は UIKit に依存しない純粋ロジックを目指す（テストしやすさ）。
+
+## 実装順序（下から上）
+
+```
+Model → Repository → Service → ViewController → View
+```
+触らない層はスキップする。
+
+## Rules (Critical)
+
+- **移行方針：新規コードからこの型を適用する。** 既存の動いている画面・Manager は現状維持（依頼が無ければリファクタしない）。
+- **新規 `.swift` は Xcode ターゲット登録を確認する。** Xcode 16 の synchronized group（`objectVersion = 77`）でフォルダ内は基本自動登録されるが、`membershipExceptions`（PBXFileSystemSynchronizedBuildFileExceptionSet）で除外され得る。ビルドで `cannot find X in scope` が出たら `TechEnglish.xcodeproj/project.pbxproj` の除外リストを確認。
+- **`main` は当面凍結。** 作業ブランチの起点・PR の base は常に `develop`。指示があるまで `main` は触らない。
+- 既存パターンを踏襲。既存ファイルを優先して修正し、新規作成は最小限。関係ないコードはリファクタしない。
+- `guard let`/`if let` で安全にアンラップ。強制アンラップ（`!`）を避ける。
+- UI 更新は必ずメインスレッド（`DispatchQueue.main.async`）。
+- クロージャのキャプチャは `[weak self]` を基本。
+- Realm の書き込みは必ずトランザクション内（`realm.write { }`）。Firestore のリスナーは `deinit` で解除。
+- Pod を追加したら `pod install` → `Podfile.lock` の差分をコミット。
+
+## Commands
+
+CocoaPods を使うため **必ず `.xcworkspace`**。コマンドは Xcode プロジェクトルート（`TechEnglish/TechEnglish/`）で実行。
+
+```bash
+cd TechEnglish
+pod install
+# ビルド（シミュレータ）
+xcodebuild -workspace TechEnglish.xcworkspace -scheme TechEnglish \
+  -destination 'platform=iOS Simulator,name=iPhone 16' build
+```
+
+ビルド/アーカイブ/IPA/アップロードの完全手順は katy-company `docs/implementation/swift-guide.md`。
+
+## 参照
+
+- 目標アーキテクチャの詳細と実装テンプレート：`docs/ARCHITECTURE.md`
+- 実装ガイド・規約・チェックリスト・ビルド手順（正）：katy-company `docs/implementation/swift-guide.md`

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,168 @@
+# TechEnglish — 目標アーキテクチャ（実装部署の受け皿）
+
+TechEnglish の実装は katy-company の実装部署（`swift-implement`）が行う。
+このファイルは、実装部署がスムーズに・保守性高く書くための **目標アーキテクチャと参照テンプレート**。
+日々効かせる要点は repo root の `CLAUDE.md`、背景と型の全体像はここ。
+
+## 前提
+
+- **既存は現状の UIKit MVC（厚い VC ＋ Manager シングルトン）。移設はしない。**
+- **新規コードからこの「薄いレイヤード MVC」を適用する。** 触るついでの小さな寄せはOK、大掛かりな既存リファクタは依頼があるときだけ。
+
+## レイヤー（薄いレイヤード MVC）
+
+```
+┌──────────────────────────────────────────────┐
+│ Controller/  ViewController                   │  表示・画面遷移・入力受け（薄く）
+└───────────────┬──────────────────────────────┘
+                │ 呼ぶ
+┌───────────────▼──────────────────────────────┐
+│ Service/  ロジック・UseCase                    │  判断・加工・組み立て（UIKit非依存）
+│   ※既存の Model/Manager/ シングルトンも同役割   │
+└───────────────┬──────────────────────────────┘
+                │ プロトコル越しに参照（DI）
+┌───────────────▼──────────────────────────────┐
+│ Repository/  データ入出力の集約                 │  永続化の詳細をここに閉じ込める
+└───────────────┬──────────────────────────────┘
+                │
+┌───────────────▼──────────────────────────────┐
+│ Realm（ローカル）/ Firestore（リモート）/       │
+│ UserDefaults（設定・フラグ）                    │
+└──────────────────────────────────────────────┘
+```
+
+### 各層の責務と禁止事項
+
+| 層 | やること | やらないこと |
+|----|---------|------------|
+| ViewController | View 構築・遷移・入力を Service に渡す・結果を表示 | Realm/Firestore/UserDefaults を直接触る／ビジネス判断 |
+| Service | 判断・加工・複数 Repository の組み立て。純粋ロジック | UIKit の import（原則）／永続化の詳細 |
+| Repository | Realm/Firestore/UserDefaults の read/write を隠蔽。プロトコルで公開 | ビジネス判断／UI |
+| Model | 値オブジェクト・Realm オブジェクト | ロジック |
+
+**保守性の肝：**
+1. VC からデータ層を直接触らない（必ず Repository 越し）。
+2. Repository は**プロトコルで公開して DI**（テストで mock 差し替え）。
+3. Service は UIKit 非依存に寄せる（単体テストしやすい）。
+
+## ディレクトリ配置
+
+`TechEnglish/TechEnglish/TechEnglish/` 配下：
+
+| 種類 | 置き場 | 例 |
+|------|--------|----|
+| 画面（薄い VC） | `Controller/<機能>/` | `Quiz/QuizViewController.swift` |
+| ロジック（新規） | `Service/` | `QuizService.swift` |
+| 既存ロジック | `Model/Manager/`（レガシー） | `DailyWordManager.swift` |
+| データ入出力 | `Repository/` | `RealmMyCardRepository.swift` |
+| データモデル | `Model/` | `MyCard.swift` |
+| 再利用 View・セル | `View/Parts/` | `MyCardsCell.swift` |
+
+> `Service/` `Repository/` は最初にそこへ書く機能が作る。Xcode 16 の synchronized group なので
+> フォルダに置けば基本自動でターゲットに入る（`CLAUDE.md` の sync-group 注意点参照）。
+
+## 参照テンプレート（新規機能の型）
+
+新しく「単語カード（MyCard）一覧」を作る想定の最小スライス。**この形をコピーして機能名を差し替える。**
+※ 命名・型は既存コードの実体に合わせること（下は型の説明用サンプル）。
+
+### 1. Repository（プロトコル＋具象）
+
+```swift
+// Repository/MyCardRepository.swift
+protocol MyCardRepository {
+    func fetchAll() -> [MyCard]
+    func add(_ card: MyCard) throws
+}
+
+// Repository/RealmMyCardRepository.swift
+import RealmSwift
+
+final class RealmMyCardRepository: MyCardRepository {
+    private let realm: Realm
+    init(realm: Realm = try! Realm()) { self.realm = realm }
+
+    func fetchAll() -> [MyCard] {
+        // Realm オブジェクト → 値オブジェクトへ変換して返す（Realm 型を外に漏らさない）
+        realm.objects(MyCardObject.self).map { $0.toDomain() }
+    }
+
+    func add(_ card: MyCard) throws {
+        try realm.write {                       // ← 書き込みは必ず transaction 内
+            realm.add(MyCardObject(from: card), update: .modified)
+        }
+    }
+}
+```
+
+### 2. Service（ロジック・UIKit 非依存）
+
+```swift
+// Service/MyCardService.swift
+final class MyCardService {
+    private let repository: MyCardRepository   // ← プロトコルに依存（DI）
+    init(repository: MyCardRepository = RealmMyCardRepository()) {
+        self.repository = repository
+    }
+
+    func cards() -> [MyCard] { repository.fetchAll() }
+
+    func save(word: String, sentence: String) throws {
+        // 判断・バリデーションはここ（VC ではなく Service）
+        let trimmed = word.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty else { throw AppError.emptyWord }
+        try repository.add(MyCard(word: trimmed, sentence: sentence))
+    }
+}
+```
+
+### 3. ViewController（薄く）
+
+```swift
+// Controller/MyCards/MyCardsViewController.swift
+final class MyCardsViewController: UIViewController {
+    private let service = MyCardService()      // 本番は既定 DI、テストは差し替え
+
+    private func reload() {
+        let cards = service.cards()
+        DispatchQueue.main.async { [weak self] in   // ← UI 更新はメインスレッド
+            self?.render(cards)
+        }
+    }
+
+    private func onSaveTapped(word: String, sentence: String) {
+        do {
+            try service.save(word: word, sentence: sentence)
+            reload()
+        } catch {
+            presentError(error)                 // 表示だけ。判断は Service 済み
+        }
+    }
+}
+```
+
+VC は「表示・遷移・入力を Service に渡す」だけ。判断とデータ入出力は下の層に降りている。
+
+## 技術スタック
+
+UIKit / SnapKit / FSCalendar / Realm(RealmSwift) / Firebase(Firestore, Analytics) /
+RevenueCat（entitlement `"ad_free"`）/ Google Mobile Ads / SwiftLinkPreview。
+正は `Podfile`。
+
+## 既存の主要な仕組み（現状把握）
+
+- **起動フロー（AppDelegate）**：通知許可 → `FirebaseApp.configure()` → `PurchaseManager.shared.configure()`。
+- **Manager パターン（レガシー Service）**：`static let shared` + `private init()`。設定は `UserDefaults` プロパティで公開、
+  状態変化は `NotificationCenter` の named notification で伝播（例：`PurchaseManager.adFreeStatusChangedNotification`）。
+- **課金**：RevenueCat Non-Consumable。`PurchaseManager.shared.isAdFree`（UserDefaults キャッシュ）で同期参照。
+
+新規実装ではこれらを「Service 層の先例」として踏襲しつつ、データ入出力は Repository に寄せる。
+
+## Git 運用
+
+`main` 凍結。`develop` 中心。作業ブランチの起点・PR base は常に `develop`。
+
+## 正のドキュメント
+
+規約・チェックリスト・ビルド/アップロードの完全手順は
+katy-company `docs/implementation/swift-guide.md`。


### PR DESCRIPTION
## 概要
実装を katy-company 実装部署（`swift-implement`）が担う前提で、TechEnglish 側にプロジェクト固有の**目標アーキテクチャ・置き場・規約**を明文化した。

## 変更内容
- **`CLAUDE.md`**（repo root）— 実装前に最初に読むガイド。薄いレイヤードMVC、Xcode16 sync-group の注意、`develop` base、Realm トランザクション / メインスレッド更新などのルールを集約。
- **`docs/ARCHITECTURE.md`** — 目標型の詳細と参照テンプレート（Repositoryプロトコル → Service → 薄いVC の最小スライス）。

## 方針
- 目標型：**薄いレイヤードMVC**（VC薄く → Service → Repository → データ）
- 移行：**新規コードから適用**。既存の動いている画面・Manager は移設しない。

## 確認手順
- `CLAUDE.md` / `docs/ARCHITECTURE.md` を読み、置き場・契約・テンプレートが実装時の指針として成立しているか確認。
- ドキュメントのみの変更のためビルドへの影響なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)