### PR TITLE
feat(iap): 広告オフ導線をクイズ側(Tab1)に置き、導線別に計測できるようにする

### DIFF
--- a/TechEnglish/TechEnglish/Controller/LearnContainerViewController.swift
+++ b/TechEnglish/TechEnglish/Controller/LearnContainerViewController.swift
@@ -33,7 +33,14 @@ class LearnContainerViewController: UIViewController {
         view.backgroundColor = EditorTheme.editorBackground
         applyEditorTheme()
         setPageView()
+        setupLeftNavBarButton()
         checkIsDescription()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(updateRemoveAdsButtonVisibility),
+            name: PurchaseManager.adFreeStatusChangedNotification,
+            object: nil
+        )
     }
     
     // MARK: - Theme
@@ -88,8 +95,41 @@ class LearnContainerViewController: UIViewController {
         pageViewController.setViewControllers([viewControllers[0]], direction: .forward, animated: false, completion: nil)
     }
     
+    // MARK: - Remove Ads (Paywall)
+
+    private func setupLeftNavBarButton() {
+        updateRemoveAdsButtonVisibility()
+    }
+
+    /// 広告オフ未購入のときだけ「広告オフ」導線を出す
+    @objc private func updateRemoveAdsButtonVisibility() {
+        guard !PurchaseManager.shared.isAdFree else {
+            navigationItem.leftBarButtonItem = nil
+            return
+        }
+        let removeAdsButton = UIBarButtonItem(
+            image: UIImage(systemName: "nosign"),
+            style: .plain,
+            target: self,
+            action: #selector(showRemoveAds)
+        )
+        removeAdsButton.tintColor = EditorTheme.accentPrimary
+        navigationItem.leftBarButtonItem = removeAdsButton
+    }
+
+    @objc private func showRemoveAds() {
+        let removeAdsVC = RemoveAdsViewController(source: .learnNav)
+        if #available(iOS 15.0, *) {
+            if let sheet = removeAdsVC.sheetPresentationController {
+                sheet.detents = [.medium(), .large()]
+                sheet.prefersGrabberVisible = true
+            }
+        }
+        present(removeAdsVC, animated: true)
+    }
+
     // MARK: - Helper Functions
-    
+
     func checkIsDescription() {
         let hasCompletedOnboarding = UserDefaults.standard.bool(forKey: "hasCompletedFirstTimeOnboarding")
         if !hasCompletedOnboarding {

--- a/TechEnglish/TechEnglish/Controller/MyCardsViewController.swift
+++ b/TechEnglish/TechEnglish/Controller/MyCardsViewController.swift
@@ -134,7 +134,7 @@ class MyCardsViewController: UIViewController, MyCardsInputDelegate {
     }
 
     @objc func showRemoveAds() {
-        let removeAdsVC = RemoveAdsViewController()
+        let removeAdsVC = RemoveAdsViewController(source: .myCardsNav)
         if #available(iOS 15.0, *) {
             if let sheet = removeAdsVC.sheetPresentationController {
                 sheet.detents = [.medium(), .large()]

--- a/TechEnglish/TechEnglish/Controller/Quiz/QuizViewController.swift
+++ b/TechEnglish/TechEnglish/Controller/Quiz/QuizViewController.swift
@@ -11,7 +11,14 @@ class QuizViewController: UIViewController {
     
     // MARK: - Interstitial Ad
     private var interstitialAd: InterstitialAd?
-    
+
+    // MARK: - Remove Ads (Paywall)
+    /// クイズ完了時にだけ出す「広告オフ」導線。割込広告の直後で、痛みが最も近い場所。
+    private let removeAdsButton = EditorButton()
+
+    /// 全問終えて完了表示になっているか
+    private var isQuizCompleted: Bool { currentQuestionIndex >= questions.count }
+
     // MARK: - Initializer
     init(questions: [Quiz], navTitle: String) {
         self.questions = questions
@@ -30,6 +37,12 @@ class QuizViewController: UIViewController {
         showQuestion()
         setupResetButton()
         loadInterstitialAd()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(updateRemoveAdsButtonVisibility),
+            name: PurchaseManager.adFreeStatusChangedNotification,
+            object: nil
+        )
     }
 
     // MARK: - Setup UI
@@ -80,6 +93,37 @@ class QuizViewController: UIViewController {
             button.addTarget(self, action: #selector(answerTapped(_:)), for: .touchUpInside)
         }
 
+        // 広告オフ導線（クイズ完了時のみ表示）
+        removeAdsButton.style = .primary
+        removeAdsButton.setTitle(NSLocalizedString("quiz_remove_ads_button", comment: ""), for: .normal)
+        removeAdsButton.addTarget(self, action: #selector(removeAdsTapped), for: .touchUpInside)
+        removeAdsButton.isHidden = true
+
+        view.addSubview(removeAdsButton)
+        removeAdsButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            removeAdsButton.topAnchor.constraint(equalTo: gridStack.bottomAnchor, constant: 32),
+            removeAdsButton.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            removeAdsButton.heightAnchor.constraint(equalToConstant: 48)
+        ])
+    }
+
+    // MARK: - Remove Ads (Paywall)
+
+    /// クイズ完了時かつ未購入のときだけ「広告オフ」導線を出す
+    @objc private func updateRemoveAdsButtonVisibility() {
+        removeAdsButton.isHidden = !(isQuizCompleted && !PurchaseManager.shared.isAdFree)
+    }
+
+    @objc private func removeAdsTapped() {
+        let removeAdsVC = RemoveAdsViewController(source: .quizEnd)
+        if #available(iOS 15.0, *) {
+            if let sheet = removeAdsVC.sheetPresentationController {
+                sheet.detents = [.medium(), .large()]
+                sheet.prefersGrabberVisible = true
+            }
+        }
+        present(removeAdsVC, animated: true)
     }
     
     // MARK: - Reset Button
@@ -96,6 +140,7 @@ class QuizViewController: UIViewController {
 
     // MARK: - Show Question
     func showQuestion() {
+        updateRemoveAdsButtonVisibility()
         guard currentQuestionIndex < questions.count else {
             questionLabel.text = "Quiz Completed!"
             buttons.forEach { $0.isHidden = true }

--- a/TechEnglish/TechEnglish/Controller/RemoveAds/RemoveAdsViewController.swift
+++ b/TechEnglish/TechEnglish/Controller/RemoveAds/RemoveAdsViewController.swift
@@ -8,7 +8,34 @@
 import UIKit
 import FirebaseAnalytics
 
+/// paywall をどの導線から開いたか（Firebase の `source` パラメータに載せる）。
+/// どの導線が購入に効いたかを比較するために使う。
+enum PaywallSource: String {
+    /// Learn タブ（クイズがある1ページ目）の常設バーボタン
+    case learnNav = "learn_nav"
+    /// My Cards タブの常設バーボタン
+    case myCardsNav = "mycards_nav"
+    /// クイズ完了時に出るボタン
+    case quizEnd = "quiz_end"
+}
+
 final class RemoveAdsViewController: UIViewController {
+
+    // MARK: - Properties
+
+    /// この paywall を開いた導線。計測にのみ使う。
+    private let source: PaywallSource
+
+    // MARK: - Initializer
+
+    init(source: PaywallSource) {
+        self.source = source
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     // MARK: - UI
 
@@ -41,7 +68,7 @@ final class RemoveAdsViewController: UIViewController {
 
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        Analytics.logEvent("paywall_view", parameters: nil)
+        Analytics.logEvent("paywall_view", parameters: ["source": source.rawValue])
     }
 
     // MARK: - Layout
@@ -139,7 +166,7 @@ final class RemoveAdsViewController: UIViewController {
 
     @objc private func purchaseTapped() {
         setLoading(true)
-        PurchaseManager.shared.purchaseAdFree { [weak self] success, userCancelled, error in
+        PurchaseManager.shared.purchaseAdFree(source: source) { [weak self] success, userCancelled, error in
             guard let self = self else { return }
             self.setLoading(false)
             if userCancelled { return }

--- a/TechEnglish/TechEnglish/Model/Manager/PurchaseManager.swift
+++ b/TechEnglish/TechEnglish/Model/Manager/PurchaseManager.swift
@@ -60,8 +60,11 @@ final class PurchaseManager: NSObject {
     // MARK: - Purchase
 
     /// 広告オフ商品を購入する
-    /// - Parameter completion: (成功, ユーザーキャンセル, エラー)。メインスレッドで呼ばれる。
-    func purchaseAdFree(completion: @escaping (_ success: Bool, _ userCancelled: Bool, _ error: Error?) -> Void) {
+    /// - Parameters:
+    ///   - source: どの paywall 導線から購入されたか（計測用）
+    ///   - completion: (成功, ユーザーキャンセル, エラー)。メインスレッドで呼ばれる。
+    func purchaseAdFree(source: PaywallSource,
+                        completion: @escaping (_ success: Bool, _ userCancelled: Bool, _ error: Error?) -> Void) {
         Purchases.shared.getOfferings { [weak self] offerings, error in
             if let error = error {
                 completion(false, false, error)
@@ -85,7 +88,7 @@ final class PurchaseManager: NSObject {
                     self.updateAdFree(from: customerInfo)
                 }
                 if self.isAdFree {
-                    self.logPurchase(package: package)
+                    self.logPurchase(package: package, source: source)
                 }
                 completion(self.isAdFree, false, nil)
             }
@@ -126,12 +129,14 @@ final class PurchaseManager: NSObject {
     }
 
     /// 購入成功を Firebase に記録（ファネル計測用。RevenueCat 側は自動計測）。
-    private func logPurchase(package: Package) {
+    /// `source` は paywall_view と同じ値で、どの導線が購入まで運んだかを突き合わせる。
+    private func logPurchase(package: Package, source: PaywallSource) {
         let product = package.storeProduct
         Analytics.logEvent(AnalyticsEventPurchase, parameters: [
             AnalyticsParameterValue: NSDecimalNumber(decimal: product.price).doubleValue,
             AnalyticsParameterCurrency: product.currencyCode ?? "",
-            AnalyticsParameterItemID: product.productIdentifier
+            AnalyticsParameterItemID: product.productIdentifier,
+            "source": source.rawValue
         ])
     }
 }

--- a/TechEnglish/TechEnglish/en.lproj/Localizable.strings
+++ b/TechEnglish/TechEnglish/en.lproj/Localizable.strings
@@ -257,3 +257,5 @@
 "remove_ads_restore_none_title" = "Nothing to Restore";
 "remove_ads_restore_none_message" = "No previous purchase was found for this Apple ID.";
 "remove_ads_error_title" = "Error";
+
+"quiz_remove_ads_button" = "Turn Off Ads";

--- a/TechEnglish/TechEnglish/ja.lproj/Localizable.strings
+++ b/TechEnglish/TechEnglish/ja.lproj/Localizable.strings
@@ -266,3 +266,5 @@
 "remove_ads_restore_none_title" = "復元できる購入がありません";
 "remove_ads_restore_none_message" = "このApple IDでの購入履歴が見つかりませんでした。";
 "remove_ads_error_title" = "エラー";
+
+"quiz_remove_ads_button" = "広告をオフにする";


### PR DESCRIPTION
## 概要

広告オフ(買い切り)の paywall 導線が **Tab2「My Cards」だけ**にあり、割込広告が実際に出る場所（**Tab1 Learn のクイズ**）と購入導線が分離していた。母数が大きく痛みが近い Tab1 側に導線を置き、あわせて **どの導線が購入に効いたか** を計測できるようにする。

PM判断: 2026-07-28。Tab1 は起動時デフォルトタブ＝全ユーザーが通る。Tab2 は「自分でカードを作る」能動ユーザーのみで、`paywall_view` の母数がここでさらに絞られると「そもそも誰か払うか」の検証が成立しない。

## 変更内容

- **LearnContainerViewController（Tab1）**: 左ナビバーに「広告オフ」バーボタンを常設。未購入時のみ表示し、`adFreeStatusChangedNotification` で購入後に自動で消える（MyCards と同じ作法）。
- **QuizViewController**: 全問終了（`Quiz Completed!`）のときだけ「広告オフ」ボタンを表示。リセット・次の問題で隠れる。
  - **インタースティシャル直後の自動シート表示はしない**（離脱・低評価リスクを避けるPM判断）。押せるボタンを置くだけ。
- **MyCards の既存導線は残す**。削る理由がなく、`source` で「どっちが効いたか」を比較できる方が価値がある。
- **`PaywallSource`（`learn_nav` / `mycards_nav` / `quiz_end`）を追加**し、`paywall_view` と `purchase` の**両方**に `source` を付与。これまで `paywall_view` は `parameters: nil` で導線が区別できなかった。
- ja/en に `quiz_remove_ads_button` を追加。

## 設計メモ

- `PaywallSource` は新規ファイルにせず `RemoveAdsViewController.swift` に置いた。このプロジェクトの Xcode16 synchronized group は `membershipExceptions` に列挙されたファイルだけが target 対象で、新規 `.swift` は pbxproj 追記が必要になるため、その罠を踏まないようにした。
- `RemoveAdsViewController` は `init(source:)` に変更（既存 `QuizViewController` と同じ init パターン）。

## 確認手順

1. `TechEnglish.xcworkspace` を開く（ビルド確認済み: iPhone 16 / iOS 18.2 simulator, `** BUILD SUCCEEDED **`）
2. **Tab1 Learn** の左上に 🚫 ボタンが出て、タップで paywall が開くこと
3. クイズを最後まで解く → `Quiz Completed!` の下に「広告をオフにする」ボタンが出ること。リセットすると消えること
4. Tab2 My Cards の既存導線も従来どおり動くこと
5. 実機 + Sandbox で購入 → 3つの導線すべてが消えること
6. Firebase で `paywall_view` / `purchase` に `source` が載っていること（`learn_nav` / `mycards_nav` / `quiz_end`）

## 注意（別件・要確認）

作業中、**`project.pbxproj` が編集外で書き換わり `Controller/RemoveAds/RemoveAdsViewController.swift` が `membershipExceptions` から消えていた**（＝ビルド対象外になり `cannot find type 'PaywallSource'` で失敗）。HEAD の状態に戻して解決済みで本PRに差分は含まないが、Xcode を開いた状態だと再発しうる。develop 側の pbxproj は正常。

🤖 Generated with [Claude Code](https://claude.com/claude-code)